### PR TITLE
front: login ui구현

### DIFF
--- a/frontend/lib/screens/login/login.dart
+++ b/frontend/lib/screens/login/login.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'dart:ui';
-import './settingName.dart';
+import './setting_name.dart';
 
 class Login extends StatelessWidget {
   const Login({super.key});

--- a/frontend/lib/screens/login/login.dart
+++ b/frontend/lib/screens/login/login.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'dart:ui';
+import './settingName.dart';
+
+class Login extends StatelessWidget {
+  const Login({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+
+      return Settingname(); // login -> if 기존 회원: nickname 패쓰, db에 있는거 가져오기/elif 새로운회원: nickname 설정 -> 시작하기page
+  }
+}
+

--- a/frontend/lib/screens/login/login.dart
+++ b/frontend/lib/screens/login/login.dart
@@ -5,10 +5,112 @@ import './setting_name.dart';
 class Login extends StatelessWidget {
   const Login({super.key});
 
+  void _handleLogin(BuildContext context, String provider) async {
+    String? socialId;
+    try {
+      if (provider == 'kakao') {
+        print("카카오 로그인 실행");
+      } else if (provider == 'google') {
+        print("구글 로그인 실행");
+      }
+
+      bool isNewUser = true;
+      if (isNewUser) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => Settingname()),
+        );
+      } else {
+        // Navigator.push(
+        //   context,
+        //   MaterialPageRoute(builder: (context) => home()),
+        // )
+      }
+    } catch (error) {
+      print("$provider 로그인Error : $error");
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-
-      return Settingname(); // login -> if 기존 회원: nickname 패쓰, db에 있는거 가져오기/elif 새로운회원: nickname 설정 -> 시작하기page
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                // 놓치지마 로고 img
+              ),
+              Text(
+                "세상의 모든 프로모션을 모아 한눈에",
+                style: TextStyle(
+                  color: Colors.grey[700],
+                  fontWeight: FontWeight.w600,
+                  fontSize: 16,
+                ),
+              ),
+              SizedBox(height: 100), // sparser()로 해야하나?
+              Container(
+                width: double.infinity,
+                height: 60,
+                child: ElevatedButton.icon(
+                  onPressed: () {
+                    _handleLogin(context, 'kakao');
+                  },
+                  // icon: Image(im),
+                  label: Text(
+                    "카카오로 시작하기",
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.black,
+                    ),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Color(0xFFFDE500),
+                    disabledBackgroundColor: Color(0xFFFDE500),
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                ),
+              ),
+              SizedBox(height: 8),
+              Container(
+                // google로 시작하기 버튼
+                width: double.infinity,
+                height: 60,
+                child: ElevatedButton.icon(
+                  onPressed: () {
+                    _handleLogin(context, 'google');
+                  },
+                  //icon: , google icon삽입
+                  label: Text(
+                    "Google로 시작하기",
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.black,
+                    ),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.white,
+                    disabledBackgroundColor: Colors.white,
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      side: BorderSide(color: Colors.grey[900]!, width: 1.0),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
-

--- a/frontend/lib/screens/login/settingName.dart
+++ b/frontend/lib/screens/login/settingName.dart
@@ -1,6 +1,7 @@
-import 'package:flutter/material.dart';
 import 'dart:ui';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:frontend/screens/login/nameComplete.dart';
 
 class Settingname extends StatefulWidget {
   const Settingname({super.key});
@@ -10,9 +11,33 @@ class Settingname extends StatefulWidget {
 }
 
 class _SettingnameState extends State<Settingname> {
+  final _nicknameController = TextEditingController();
+  bool _isButtonEnabled = false;
 
-  void submitButton(buttons){
-
+  @override
+  void initState(){
+    super.initState();
+    _nicknameController.addListener(_validateInput);
+  }
+  @override
+  void dispose(){
+    _nicknameController.dispose();
+    super.dispose();
+  }
+  void _validateInput(){
+    setState(() {
+      int textLength = _nicknameController.text.length;
+      _isButtonEnabled = textLength >= 2 && textLength <= 8;
+    });
+  }
+  void submitButton(String nickname){
+    // nickname needs to be sent to backend
+    print("제출할 닉네임: $nickname");
+    //go to next page
+    Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => Namecomplete()),
+    );
   }
 
   @override
@@ -39,6 +64,7 @@ class _SettingnameState extends State<Settingname> {
             SizedBox(height: 20),
             Container(
               child: TextField(
+                controller: _nicknameController,
                 decoration: InputDecoration(
                   hintText: "닉네임 입력",
                   hintStyle: TextStyle(
@@ -69,9 +95,9 @@ class _SettingnameState extends State<Settingname> {
               width: double.infinity, // 너비를 화면에 꽉 채움
               height: 70, // 버튼 높이 지정 (선택 사항)
               child: ElevatedButton(
-                onPressed: () {
-                  submitButton('next');
-                },
+                onPressed:_isButtonEnabled ? () {
+                  submitButton(_nicknameController.text);
+                }:null,
                 child: Text(
                   "다음",
                   style: TextStyle(
@@ -81,7 +107,8 @@ class _SettingnameState extends State<Settingname> {
                   ),
                 ),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Color(0xFFFFD9DC),
+                  backgroundColor: Color(0xFFFF333F),
+                  disabledBackgroundColor: Color(0xFFFFD9DC),
                   elevation: 0,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8)

--- a/frontend/lib/screens/login/settingName.dart
+++ b/frontend/lib/screens/login/settingName.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'dart:ui';
+import 'package:flutter/services.dart';
+
+class Settingname extends StatefulWidget {
+  const Settingname({super.key});
+
+  @override
+  State<Settingname> createState() => _SettingnameState();
+}
+
+class _SettingnameState extends State<Settingname> {
+
+  void submitButton(buttons){
+
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar:AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+                "닉네임을 입력하세요",
+                style: TextStyle(
+                    color: Colors.grey[800],
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700,
+                )
+            ),
+            SizedBox(height: 20),
+            Container(
+              child: TextField(
+                decoration: InputDecoration(
+                  hintText: "닉네임 입력",
+                  hintStyle: TextStyle(
+                    color: Colors.grey[400]
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Color(0xFFFF333F), width: 2.0),
+                    borderRadius: BorderRadius.circular(12.0),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Color(0xFFFF333F), width: 2.0),
+                    borderRadius: BorderRadius.circular(12.0),
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(height: 10),
+            Text(
+              "2~8자까지 입력할 수 있어요.",
+              style: TextStyle(
+                color: Colors.grey[400],
+                fontSize: 14,
+                fontWeight: FontWeight.normal
+              ),
+            ),
+            Spacer(),
+            Container(
+              width: double.infinity, // 너비를 화면에 꽉 채움
+              height: 70, // 버튼 높이 지정 (선택 사항)
+              child: ElevatedButton(
+                onPressed: () {
+                  submitButton('next');
+                },
+                child: Text(
+                  "다음",
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.white,
+                  ),
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Color(0xFFFFD9DC),
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8)
+                  )
+                ),
+            ),
+            ),
+            SizedBox(height: 20),
+            ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/login/setting_name.dart
+++ b/frontend/lib/screens/login/setting_name.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:frontend/screens/login/nameComplete.dart';
+import 'package:frontend/screens/login/setting_name_complete.dart';
 
 class Settingname extends StatefulWidget {
   const Settingname({super.key});
@@ -36,7 +36,9 @@ class _SettingnameState extends State<Settingname> {
     //go to next page
     Navigator.pushReplacement(
         context,
-        MaterialPageRoute(builder: (context) => Namecomplete()),
+        MaterialPageRoute(
+            builder: (context) => Namecomplete(nickName: nickname)
+        ),
     );
   }
 
@@ -92,8 +94,8 @@ class _SettingnameState extends State<Settingname> {
             ),
             Spacer(),
             Container(
-              width: double.infinity, // 너비를 화면에 꽉 채움
-              height: 70, // 버튼 높이 지정 (선택 사항)
+              width: double.infinity,
+              height: 60,
               child: ElevatedButton(
                 onPressed:_isButtonEnabled ? () {
                   submitButton(_nicknameController.text);

--- a/frontend/lib/screens/login/setting_name.dart
+++ b/frontend/lib/screens/login/setting_name.dart
@@ -15,53 +15,50 @@ class _SettingnameState extends State<Settingname> {
   bool _isButtonEnabled = false;
 
   @override
-  void initState(){
+  void initState() {
     super.initState();
     _nicknameController.addListener(_validateInput);
   }
+
   @override
-  void dispose(){
+  void dispose() {
     _nicknameController.dispose();
     super.dispose();
   }
-  void _validateInput(){
+
+  void _validateInput() {
     setState(() {
       int textLength = _nicknameController.text.length;
       _isButtonEnabled = textLength >= 2 && textLength <= 8;
     });
   }
-  void submitButton(String nickname){
+
+  void submitButton(String nickname) {
     // nickname needs to be sent to backend
     print("제출할 닉네임: $nickname");
     //go to next page
     Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-            builder: (context) => Namecomplete(nickName: nickname)
-        ),
+      context,
+      MaterialPageRoute(builder: (context) => Namecomplete(nickName: nickname)),
     );
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar:AppBar(
-        backgroundColor: Colors.white,
-        elevation: 0,
-
-      ),
+      appBar: AppBar(backgroundColor: Colors.white, elevation: 0),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-                "닉네임을 입력하세요",
-                style: TextStyle(
-                    color: Colors.grey[800],
-                    fontSize: 24,
-                    fontWeight: FontWeight.w700,
-                )
+              "닉네임을 입력하세요",
+              style: TextStyle(
+                color: Colors.grey[800],
+                fontSize: 24,
+                fontWeight: FontWeight.w700,
+              ),
             ),
             SizedBox(height: 20),
             Container(
@@ -69,15 +66,19 @@ class _SettingnameState extends State<Settingname> {
                 controller: _nicknameController,
                 decoration: InputDecoration(
                   hintText: "닉네임 입력",
-                  hintStyle: TextStyle(
-                    color: Colors.grey[400]
-                  ),
+                  hintStyle: TextStyle(color: Colors.grey[400]),
                   enabledBorder: OutlineInputBorder(
-                    borderSide: BorderSide(color: Color(0xFFFF333F), width: 2.0),
+                    borderSide: BorderSide(
+                      color: Color(0xFFFF333F),
+                      width: 2.0,
+                    ),
                     borderRadius: BorderRadius.circular(12.0),
                   ),
                   focusedBorder: OutlineInputBorder(
-                    borderSide: BorderSide(color: Color(0xFFFF333F), width: 2.0),
+                    borderSide: BorderSide(
+                      color: Color(0xFFFF333F),
+                      width: 2.0,
+                    ),
                     borderRadius: BorderRadius.circular(12.0),
                   ),
                 ),
@@ -89,7 +90,7 @@ class _SettingnameState extends State<Settingname> {
               style: TextStyle(
                 color: Colors.grey[400],
                 fontSize: 14,
-                fontWeight: FontWeight.normal
+                fontWeight: FontWeight.normal,
               ),
             ),
             Spacer(),
@@ -97,9 +98,11 @@ class _SettingnameState extends State<Settingname> {
               width: double.infinity,
               height: 60,
               child: ElevatedButton(
-                onPressed:_isButtonEnabled ? () {
-                  submitButton(_nicknameController.text);
-                }:null,
+                onPressed: _isButtonEnabled
+                    ? () {
+                        submitButton(_nicknameController.text);
+                      }
+                    : null,
                 child: Text(
                   "다음",
                   style: TextStyle(
@@ -113,13 +116,13 @@ class _SettingnameState extends State<Settingname> {
                   disabledBackgroundColor: Color(0xFFFFD9DC),
                   elevation: 0,
                   shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8)
-                  )
+                    borderRadius: BorderRadius.circular(8),
+                  ),
                 ),
-            ),
+              ),
             ),
             SizedBox(height: 20),
-            ],
+          ],
         ),
       ),
     );

--- a/frontend/lib/screens/login/setting_name_complete.dart
+++ b/frontend/lib/screens/login/setting_name_complete.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+class Namecomplete extends StatelessWidget {
+  final String nickName;
+  const Namecomplete({
+    super.key,
+    required this.nickName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                
+              ),
+              SizedBox(height: 37),
+              Text(
+                "회원가입 완료!",
+                style: TextStyle(
+                  fontWeight: FontWeight.w700,
+                  color: Colors.grey[400],
+                ),
+              ),
+              SizedBox(height: 16),
+              RichText(
+                textAlign: TextAlign.center,
+                text: TextSpan(
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w600,
+                      height: 1.5,
+                      color: Colors.black,
+                    ),
+                    children: <TextSpan>[
+                      TextSpan(
+                        text: nickName,
+                        style: TextStyle(
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      TextSpan(
+                        text: " 님,\n환영해요!",
+                      ),
+                    ]
+                ),
+              ),
+              Spacer(),
+              Container(
+                width: double.infinity,
+                height: 60,
+                child: ElevatedButton(
+                  onPressed:(){
+
+                  },
+                  child: Text(
+                    "놓치지마 시작하기",
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                      backgroundColor: Color(0xFFFF333F),
+                      disabledBackgroundColor: Color(0xFFFF333F),
+                      elevation: 0,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8)
+                      )
+                  ),
+                ),
+              ),
+              SizedBox(height: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/login/setting_name_complete.dart
+++ b/frontend/lib/screens/login/setting_name_complete.dart
@@ -2,83 +2,75 @@ import 'package:flutter/material.dart';
 
 class Namecomplete extends StatelessWidget {
   final String nickName;
-  const Namecomplete({
-    super.key,
-    required this.nickName,
-  });
+
+  const Namecomplete({super.key, required this.nickName});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(20.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Container(
-                
-              ),
-              SizedBox(height: 37),
-              Text(
-                "회원가입 완료!",
-                style: TextStyle(
-                  fontWeight: FontWeight.w700,
-                  color: Colors.grey[400],
-                ),
-              ),
-              SizedBox(height: 16),
-              RichText(
-                textAlign: TextAlign.center,
-                text: TextSpan(
-                    style: TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.w600,
-                      height: 1.5,
-                      color: Colors.black,
-                    ),
-                    children: <TextSpan>[
-                      TextSpan(
-                        text: nickName,
-                        style: TextStyle(
-                          fontWeight: FontWeight.w800,
-                        ),
-                      ),
-                      TextSpan(
-                        text: " 님,\n환영해요!",
-                      ),
-                    ]
-                ),
-              ),
-              Spacer(),
-              Container(
-                width: double.infinity,
-                height: 60,
-                child: ElevatedButton(
-                  onPressed:(){
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          children: [
+            Spacer(flex: 2),
+            Container(
+              // celebration 사진넣기
+              height: 100,
 
-                  },
-                  child: Text(
-                    "놓치지마 시작하기",
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                      color: Colors.white,
-                    ),
+            ),
+            SizedBox(height: 37),
+            Text(
+              "회원가입 완료!",
+              style: TextStyle(
+                fontWeight: FontWeight.w700,
+                color: Colors.grey[400],
+              ),
+            ),
+            SizedBox(height: 16),
+            RichText(
+              textAlign: TextAlign.center,
+              text: TextSpan(
+                style: TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.w600,
+                  height: 1.5,
+                  color: Colors.black,
+                ),
+                children: <TextSpan>[
+                  TextSpan(
+                    text: nickName,
+                    style: TextStyle(fontWeight: FontWeight.w800),
                   ),
-                  style: ElevatedButton.styleFrom(
-                      backgroundColor: Color(0xFFFF333F),
-                      disabledBackgroundColor: Color(0xFFFF333F),
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8)
-                      )
+                  TextSpan(text: " 님,\n환영해요!"),
+                ],
+              ),
+            ),
+            Spacer(flex: 2),
+            Container(
+              width: double.infinity,
+              height: 60,
+              child: ElevatedButton(
+                onPressed: () {},
+                child: Text(
+                  "놓치지마 시작하기",
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.white,
+                  ),
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Color(0xFFFF333F),
+                  disabledBackgroundColor: Color(0xFFFF333F),
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
                   ),
                 ),
               ),
-              SizedBox(height: 20),
-            ],
-          ),
+            ),
+            SizedBox(height: 20),
+          ],
         ),
       ),
     );

--- a/frontend/lib/screens/login/setting_name_complete.dart
+++ b/frontend/lib/screens/login/setting_name_complete.dart
@@ -16,7 +16,6 @@ class Namecomplete extends StatelessWidget {
             Container(
               // celebration 사진넣기
               height: 100,
-
             ),
             SizedBox(height: 37),
             Text(


### PR DESCRIPTION
# 변경점 👍
login페이지 구현

# 스크린샷 🖼
<img width="493" height="1000" alt="image" src="https://github.com/user-attachments/assets/a30c3b6b-6553-4861-a5f0-739b443fd78d" />

 <img width="538" height="892" alt="image" src="https://github.com/user-attachments/assets/bb4839b2-38e7-4997-b320-465581e5185b" />
 
<img width="538" height="892" alt="image" src="https://github.com/user-attachments/assets/0dd65b4b-e960-4cb0-b573-05b03e8effc0" />

# 비고 ✏
구현필요: 
이전화면으로 돌아가는 아이콘 수정
img(로고, celebrate img ) 삽입
한글 폰트: bold적용X => font 지정
 <br>
 
 사용하지 않은 항목은 모두 지워주세요.
